### PR TITLE
Debug 429 error on slider state update

### DIFF
--- a/lib/custom_code/actions/post_slider_value.dart
+++ b/lib/custom_code/actions/post_slider_value.dart
@@ -36,12 +36,17 @@ Future<dynamic> postSliderValue(double value, String parcela,
         .timeout(const Duration(seconds: 10));
 
     completer.complete({
+      // Maintain both fields for downstream consumers
       'status': response.statusCode,
+      'statusCode': response.statusCode,
+      'headers': response.headers,
       'body': jsonDecode(response.body),
     });
   } catch (e) {
     completer.complete({
       'status': 500,
+      'statusCode': 500,
+      'headers': const <String, String>{},
       'body': 'Erro na requisição: $e',
     });
   }

--- a/lib/custom_code/actions/post_slider_value_throttled.dart
+++ b/lib/custom_code/actions/post_slider_value_throttled.dart
@@ -36,11 +36,15 @@ Future<dynamic> postSliderValueThrottled(double value, String parcela,
 
     completer.complete({
       'status': response.statusCode,
+      'statusCode': response.statusCode,
+      'headers': response.headers,
       'body': jsonDecode(response.body),
     });
   } catch (e) {
     completer.complete({
       'status': 500,
+      'statusCode': 500,
+      'headers': const <String, String>{},
       'body': 'Erro na requisição: $e',
     });
   }

--- a/lib/custom_code/widgets/dynamic_dropdown_f_f.dart
+++ b/lib/custom_code/widgets/dynamic_dropdown_f_f.dart
@@ -10,6 +10,8 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
+import '/custom_code/ApiGate.dart';
+import '/custom_code/actions/post_slider_value.dart';
 
 class DynamicDropdownFF extends StatefulWidget {
   const DynamicDropdownFF(
@@ -135,13 +137,20 @@ class _DynamicDropdownFFState extends State<DynamicDropdownFF> {
               // Call the FlutterFlow action with the new value
               // await widget.onOptionSelected(newValue);
 
-              // 2. Call the API
-              final response = await postSliderValue(
-                  FFAppState().customSliderValue,
-                  _selectedValue ?? '0',
-                  'porQtdeParcelas',
-                  '21220',
-                  '');
+              // 2. Call the API, gated and with backoff support
+              final response = await ApiGate.run(() => postSliderValue(
+                    FFAppState().customSliderValue,
+                    _selectedValue ?? '0',
+                    'porQtdeParcelas',
+                    '21220',
+                    '',
+                  ));
+
+              // 429 handling via headers (if returned without throw)
+              if ((response['statusCode'] as int?) == 429) {
+                ApiGate.backoffFromHeaders(response['headers'] as Map?);
+                return;
+              }
               // 3. Update App State
               FFAppState().update(() {
                 FFAppState().maxAllowedValue = double.tryParse(

--- a/lib/custom_code/widgets/on_end_slider.dart
+++ b/lib/custom_code/widgets/on_end_slider.dart
@@ -149,12 +149,21 @@ class _OnEndSliderState extends State<OnEndSlider> {
         _globalNextAllowedAt = DateTime.now().add(const Duration(seconds: 2));
 
         _lastSentValue = finalValue;
-        FFAppState().update(() {
-          FFAppState().totalParcela =
-              response['body']?['dados']?['valorEmprestimoForma'];
-          FFAppState().valorParcela =
-              response['body']?['dados']?['valorParcela'];
-        });
+        // Avoid global rebuilds: assign directly without notifyListeners
+        final String? totalForma =
+            response['body']?['dados']?['valorEmprestimoForma']?.toString();
+        final String? valorParcela =
+            response['body']?['dados']?['valorParcela']?.toString();
+        if (totalForma != null) {
+          FFAppState().totalParcela = totalForma;
+        }
+        if (valorParcela != null) {
+          FFAppState().valorParcela = valorParcela;
+        }
+        // Notify host optionally without forcing app-wide update
+        if (widget.onApiSuccess != null && valorParcela != null) {
+          await widget.onApiSuccess!(valorParcela);
+        }
       } finally {
         _requestInFlight = false;
         if (_pendingValue != null) {
@@ -232,13 +241,14 @@ class _OnEndSliderState extends State<OnEndSlider> {
                 final ui = _capValueToMax(v);
                 setState(() => _currentValue = ui);
 
+                // Avoid notifying listeners during drag to prevent page rebuilds
+                // that could trigger repeated API calls in generated widgets.
+                // Update local app state fields without notify.
                 final f = NumberFormat.currency(
                     locale: 'pt_BR', symbol: 'R\$ ', decimalDigits: 2);
-                FFAppState().update(() {
-                  FFAppState().ValorFormatado = ui; // numeric
-                  FFAppState().valorParcelaAlterado =
-                      f.format(ui); // display-only
-                });
+                FFAppState().ValorFormatado = ui; // numeric (no notify)
+                FFAppState().valorParcelaAlterado =
+                    f.format(ui); // display-only (no notify)
               },
               onChangeEnd: (v) => _handleSliderChange(
                   _capValueToMax(v)), // API logic (debounced/guarded)

--- a/lib/pages/emprestimo/emprestimo_widget.dart
+++ b/lib/pages/emprestimo/emprestimo_widget.dart
@@ -27,6 +27,7 @@ class EmprestimoWidget extends StatefulWidget {
 
 class _EmprestimoWidgetState extends State<EmprestimoWidget> {
   late EmprestimoModel _model;
+  late Future<ApiCallResponse> _initialFuture;
 
   final scaffoldKey = GlobalKey<ScaffoldState>();
 
@@ -35,15 +36,18 @@ class _EmprestimoWidgetState extends State<EmprestimoWidget> {
     super.initState();
     _model = createModel(context, () => EmprestimoModel());
 
+    // Cache the initial API call so rebuilds don't refetch on every change
+    _initialFuture = SimulaEmprestimoCall.call(
+      contratante: '21220',
+      tipoSimulacao: 'processaSimulacao',
+      quantidadeParcelas: '0',
+      valorEmprestimo: '0',
+      valorParcelas: '0',
+    );
+
     // On page load action.
     SchedulerBinding.instance.addPostFrameCallback((_) async {
-      _model.dados = await SimulaEmprestimoCall.call(
-        contratante: '21220',
-        tipoSimulacao: 'processaSimulacao',
-        quantidadeParcelas: '0',
-        valorEmprestimo: '0',
-        valorParcelas: '0',
-      );
+      _model.dados = await _initialFuture;
 
       if ((_model.dados?.succeeded ?? true)) {
         FFAppState().totalParcela = getJsonField(
@@ -130,7 +134,7 @@ class _EmprestimoWidgetState extends State<EmprestimoWidget> {
     context.watch<FFAppState>();
 
     return FutureBuilder<ApiCallResponse>(
-      future: SimulaEmprestimoCall.call(),
+      future: _initialFuture,
       builder: (context, snapshot) {
         // Customize what your widget looks like when it's loading.
         if (!snapshot.hasData) {

--- a/lib/pages/teste/teste_widget.dart
+++ b/lib/pages/teste/teste_widget.dart
@@ -25,6 +25,7 @@ class TesteWidget extends StatefulWidget {
 
 class _TesteWidgetState extends State<TesteWidget> {
   late TesteModel _model;
+  late Future<ApiCallResponse> _initialFuture;
 
   final scaffoldKey = GlobalKey<ScaffoldState>();
 
@@ -33,15 +34,18 @@ class _TesteWidgetState extends State<TesteWidget> {
     super.initState();
     _model = createModel(context, () => TesteModel());
 
+    // Cache the initial API call to avoid refetching on every rebuild
+    _initialFuture = SimulaEmprestimoCall.call(
+      contratante: '21220',
+      tipoSimulacao: 'processaSimulacao',
+      quantidadeParcelas: '0',
+      valorEmprestimo: '0',
+      valorParcelas: '0',
+    );
+
     // On page load action.
     SchedulerBinding.instance.addPostFrameCallback((_) async {
-      _model.dados = await SimulaEmprestimoCall.call(
-        contratante: '21220',
-        tipoSimulacao: 'processaSimulacao',
-        quantidadeParcelas: '0',
-        valorEmprestimo: '0',
-        valorParcelas: '0',
-      );
+      _model.dados = await _initialFuture;
 
       if ((_model.dados?.succeeded ?? true)) {
         FFAppState().valorParcela = getJsonField(
@@ -104,7 +108,7 @@ class _TesteWidgetState extends State<TesteWidget> {
     context.watch<FFAppState>();
 
     return FutureBuilder<ApiCallResponse>(
-      future: SimulaEmprestimoCall.call(),
+      future: _initialFuture,
       builder: (context, snapshot) {
         // Customize what your widget looks like when it's loading.
         if (!snapshot.hasData) {


### PR DESCRIPTION
Cache initial API calls and implement API rate limiting with 429 backoff to reduce frequent API requests.

Frequent `FFAppState().update()` calls were causing repeated initial API fetches, and the dropdown API call lacked rate limiting, leading to 429 errors. This PR caches initial API futures and integrates `ApiGate` for robust 429 handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a0e1bbe-db2b-43de-8197-99ebd62e0eaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a0e1bbe-db2b-43de-8197-99ebd62e0eaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

