### PR TITLE
Debug FFAppState update 429 error

### DIFF
--- a/lib/custom_code/actions/generate_number_range_action.dart
+++ b/lib/custom_code/actions/generate_number_range_action.dart
@@ -16,9 +16,22 @@ Future<void> generateNumberRangeAction(String start, String end) async {
   final range =
       List.generate(intEnd - intStart + 1, (i) => (intStart + i).toString());
 
-  FFAppState().update(() {
-    FFAppState().dropDownList = range;
-  });
+  // Avoid notifying listeners if list hasn't actually changed
+  final List<String> current = FFAppState().dropDownList;
+  bool same = current.length == range.length;
+  if (same) {
+    for (int i = 0; i < range.length; i++) {
+      if (current[i] != range[i]) {
+        same = false;
+        break;
+      }
+    }
+  }
+  if (!same) {
+    FFAppState().update(() {
+      FFAppState().dropDownList = range;
+    });
+  }
 }
 
 // Set your action name, define your arguments and return parameter,

--- a/lib/custom_code/actions/post_slider_value.dart
+++ b/lib/custom_code/actions/post_slider_value.dart
@@ -11,37 +11,47 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'dart:async';
 
-Future<dynamic> postSliderValue(double value, String parcela,
-    String tipoSimulacao, String contratante, String valorParcela) async {
+Future<dynamic> postSliderValue(
+  double value,
+  String parcela,
+  String tipoSimulacao,
+  String contratante,
+  String valorParcela,
+) async {
   final completer = Completer<Map<String, dynamic>>();
   try {
     final uri = Uri.parse('https://api.facsistemas.com.br/simulaEmprestimo');
 
-    final headers = {
+    final headers = <String, String>{
       'Content-Type': 'application/json',
       'Authorization':
           'Basic ZmFjQ29udHJhdGFudGU6ODhiMzMyODNiOTEzYjY1Mzc3NGMyODZjNzkxN2Y1ZmQ=',
     };
 
-    final body = jsonEncode({
+    final body = jsonEncode(<String, dynamic>{
       'contratante': contratante,
       'tipoSimulacao': tipoSimulacao,
       'quantidadeParcelas': parcela,
       'valorEmprestimo': value,
-      'valorParcelas': valorParcela
+      'valorParcelas': valorParcela,
     });
 
     final response = await http
         .post(uri, headers: headers, body: body)
         .timeout(const Duration(seconds: 10));
 
+    // Return a shape compatible with both legacy and new consumers
     completer.complete({
-      'status': response.statusCode,
+      'status': response.statusCode, // legacy callers
+      'statusCode': response.statusCode, // new callers
+      'headers': response.headers,
       'body': jsonDecode(response.body),
     });
   } catch (e) {
     completer.complete({
       'status': 500,
+      'statusCode': 500,
+      'headers': const <String, String>{},
       'body': 'Erro na requisição: $e',
     });
   }

--- a/lib/custom_code/actions/post_slider_value_throttled.dart
+++ b/lib/custom_code/actions/post_slider_value_throttled.dart
@@ -35,12 +35,16 @@ Future<dynamic> postSliderValueThrottled(double value, String parcela,
         .timeout(const Duration(seconds: 10));
 
     completer.complete({
-      'status': response.statusCode,
+      'status': response.statusCode, // legacy
+      'statusCode': response.statusCode, // new
+      'headers': response.headers,
       'body': jsonDecode(response.body),
     });
   } catch (e) {
     completer.complete({
       'status': 500,
+      'statusCode': 500,
+      'headers': const <String, String>{},
       'body': 'Erro na requisição: $e',
     });
   }

--- a/lib/custom_code/widgets/dynamic_dropdown_f_f.dart
+++ b/lib/custom_code/widgets/dynamic_dropdown_f_f.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
+import '/custom_code/ApiGate.dart';
 
 class DynamicDropdownFF extends StatefulWidget {
   const DynamicDropdownFF(
@@ -135,29 +136,45 @@ class _DynamicDropdownFFState extends State<DynamicDropdownFF> {
               // Call the FlutterFlow action with the new value
               // await widget.onOptionSelected(newValue);
 
-              // 2. Call the API
-              final response = await postSliderValue(
-                  FFAppState().customSliderValue,
-                  _selectedValue ?? '0',
-                  'porQtdeParcelas',
-                  '21220',
-                  '');
-              // 3. Update App State
-              FFAppState().update(() {
-                FFAppState().maxAllowedValue = double.tryParse(
-                        response['body']?['dados']?['valorEmprestimo']) ??
-                    0.0;
-                FFAppState().parcela = newValue;
-                // // FIX: Safely parse the String into a Double for FFAppState().customSliderValue
-                FFAppState().customSliderValue = double.tryParse(
-                        response['body']?['dados']?['valorEmprestimo']) ??
-                    0.0;
+              // 2. Call the API with global gate and handle 429
+              final response = await ApiGate.run(() => postSliderValue(
+                    FFAppState().customSliderValue,
+                    _selectedValue ?? '0',
+                    'porQtdeParcelas',
+                    '21220',
+                    '',
+                  ));
 
-                FFAppState().totalParcela =
-                    response['body']?['dados']?['valorEmprestimoForma'];
-                FFAppState().valorParcela =
-                    response['body']?['dados']?['valorParcela'];
-              });
+              if ((response['statusCode'] as int?) == 429) {
+                ApiGate.backoffFromHeaders(response['headers'] as Map?);
+                return; // defer retry to gate cooldown
+              }
+
+              // 3. Update App State only on real changes
+              final String nextTotalParcela =
+                  (response['body']?['dados']?['valorEmprestimoForma'] ?? '')
+                      .toString();
+              final String nextValorParcela =
+                  (response['body']?['dados']?['valorParcela'] ?? '').toString();
+              final double nextValorEmprestimo = double.tryParse(
+                      (response['body']?['dados']?['valorEmprestimo'] ?? '0')
+                          .toString()) ??
+                  0.0;
+
+              final bool shouldUpdate =
+                  nextTotalParcela != FFAppState().totalParcela ||
+                      nextValorParcela != FFAppState().valorParcela ||
+                      nextValorEmprestimo != FFAppState().customSliderValue ||
+                      newValue != FFAppState().parcela;
+              if (shouldUpdate) {
+                FFAppState().update(() {
+                  FFAppState().maxAllowedValue = nextValorEmprestimo;
+                  FFAppState().parcela = newValue;
+                  FFAppState().customSliderValue = nextValorEmprestimo;
+                  FFAppState().totalParcela = nextTotalParcela;
+                  FFAppState().valorParcela = nextValorParcela;
+                });
+              }
             }
           },
           items: widget.options.map<DropdownMenuItem<String>>((String value) {

--- a/lib/custom_code/widgets/formatacao_valores_total.dart
+++ b/lib/custom_code/widgets/formatacao_valores_total.dart
@@ -163,12 +163,19 @@ class _FormatacaoValoresTotalState extends State<FormatacaoValoresTotal> {
         final dynamic rawValor = response['body']?['dados']?['valorEmprestimo'];
         final double valorEmprestimo = parseFlexibleDouble(rawValor);
 
-        FFAppState().update(() {
-          FFAppState().totalParcela =
-              response['body']?['dados']?['valorEmprestimoForma'];
+        final String nextTotalParcela =
+            (response['body']?['dados']?['valorEmprestimoForma'] ?? '')
+                .toString();
+        final double nextSliderValue = valorEmprestimo;
 
-          FFAppState().customSliderValue = valorEmprestimo;
-        });
+        final bool shouldUpdate = nextTotalParcela != FFAppState().totalParcela ||
+            nextSliderValue != FFAppState().customSliderValue;
+        if (shouldUpdate) {
+          FFAppState().update(() {
+            FFAppState().totalParcela = nextTotalParcela;
+            FFAppState().customSliderValue = nextSliderValue;
+          });
+        }
       } finally {
         _requestInFlight = false;
 

--- a/lib/custom_code/widgets/on_end_slider.dart
+++ b/lib/custom_code/widgets/on_end_slider.dart
@@ -149,12 +149,22 @@ class _OnEndSliderState extends State<OnEndSlider> {
         _globalNextAllowedAt = DateTime.now().add(const Duration(seconds: 2));
 
         _lastSentValue = finalValue;
-        FFAppState().update(() {
-          FFAppState().totalParcela =
-              response['body']?['dados']?['valorEmprestimoForma'];
-          FFAppState().valorParcela =
-              response['body']?['dados']?['valorParcela'];
-        });
+        final String nextTotalParcela =
+            (response['body']?['dados']?['valorEmprestimoForma'] ?? '')
+                .toString();
+        final String nextValorParcela =
+            (response['body']?['dados']?['valorParcela'] ?? '').toString();
+
+        // Only notify listeners when values actually change to avoid extra rebuilds
+        final bool shouldUpdate =
+            nextTotalParcela != FFAppState().totalParcela ||
+                nextValorParcela != FFAppState().valorParcela;
+        if (shouldUpdate) {
+          FFAppState().update(() {
+            FFAppState().totalParcela = nextTotalParcela;
+            FFAppState().valorParcela = nextValorParcela;
+          });
+        }
       } finally {
         _requestInFlight = false;
         if (_pendingValue != null) {


### PR DESCRIPTION
Reduce 429 errors by preventing redundant FFAppState updates and standardizing API error handling.

The `FFAppState().update` calls were triggering `notifyListeners`, which caused screens like `EmprestimoWidget` to rebuild and re-execute API calls, leading to a cascade of requests and 429 errors. This PR guards `FFAppState` updates to only occur on actual data changes and standardizes API response formats to enable proper rate limiting and backoff.

---
<a href="https://cursor.com/background-agent?bcId=bc-61e84287-23e4-4606-8c9e-30676e51e0f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61e84287-23e4-4606-8c9e-30676e51e0f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

